### PR TITLE
Encode URL params back to typeform URL

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -62,8 +62,8 @@
     <script>
       const initTypeform = () => {
         const urlParams = new URLSearchParams(window.location.search);
-        const firstName = urlParams.get('first_name') || ""
-        const email     = urlParams.get('email') || ""
+        const firstName = encodeURIComponent(urlParams.get('first_name')) || ""
+        const email     = encodeURIComponent(urlParams.get('email')) || ""
 
         const typeformUrl = `https://form.typeform.com/to/twD4cTZD?typeform-medium=embed-snippet#first_name=${firstName}&email=${email}`
 


### PR DESCRIPTION
Enable usage of email hidden field, to not ask the user for her password again, and risk double registration